### PR TITLE
allow to build (not runtime tested :-) with a current yocto krogoth SDK

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -317,6 +317,7 @@ if $PKG_CONFIG --exists "$2" ; then
 	AC_MSG_RESULT(yes)
 	$1_CFLAGS=$($PKG_CONFIG --cflags "$2")
 	$1_LIBS=$($PKG_CONFIG --libs "$2")
+	$1_EXISTS=yes
 else
 	AC_MSG_RESULT(no)
 fi
@@ -327,7 +328,7 @@ AC_SUBST($1_LIBS)
 
 AC_DEFUN([TUXBOX_APPS_LIB_PKGCONFIG],[
 _TUXBOX_APPS_LIB_PKGCONFIG($1,$2)
-if test -z "$$1_CFLAGS" ; then
+if test x"$$1_EXISTS" != xyes; then
 	AC_MSG_ERROR([could not find package $2]);
 fi
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -89,8 +89,16 @@ fi
 AM_CONDITIONAL(USE_TREMOR, test "$TREMOR" = "yes")
 
 # TUXBOX_APPS_LIB_PKGCONFIG(OPENSSL,openssl)
-TUXBOX_APPS_LIB_CONFIG(CURL,curl-config)
-TUXBOX_APPS_LIB_CONFIG(FREETYPE,freetype-config)
+TUXBOX_APPS_LIB_PKGCONFIG(CURL,libcurl)
+TUXBOX_APPS_LIB_PKGCONFIG(FREETYPE,freetype2)
+# fallback to curl-config (which is ugly for cross-compilation)
+if test -z "$CURL_LIBS" -a -z "$CURL_CFLAGS"; then
+	TUXBOX_APPS_LIB_CONFIG(CURL,curl-config)
+fi
+# fallback to freetype-config (which is ugly for cross-compilation)
+if test -z "$FREETYPE_LIBS" -a -z "$FREETYPE_CFLAGS"; then
+	TUXBOX_APPS_LIB_CONFIG(FREETYPE,freetype-config)
+fi
 
 TUXBOX_APPS_LIB_PKGCONFIG(PNG,libpng)
 TUXBOX_APPS_LIB_PKGCONFIG(AVFORMAT,libavformat)

--- a/lib/libdvbsub/Makefile.am
+++ b/lib/libdvbsub/Makefile.am
@@ -4,6 +4,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src \
 	-I$(top_srcdir)/src/zapit/include \
 	@AVFORMAT_CFLAGS@ \
+	@SIGC_CFLAGS@ \
 	@HWLIB_CFLAGS@
 
 AM_CPPFLAGS += -fno-rtti -fno-exceptions

--- a/lib/libtuxtxt/Makefile.am
+++ b/lib/libtuxtxt/Makefile.am
@@ -4,6 +4,7 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir)/src \
 	-I$(top_srcdir)/src/zapit/include \
 	$(FREETYPE_CFLAGS) \
+	@SIGC_CFLAGS@ \
 	@HWLIB_CFLAGS@
 
 AM_CPPFLAGS += -fno-rtti -fno-exceptions

--- a/src/gui/channellist.cpp
+++ b/src/gui/channellist.cpp
@@ -1080,10 +1080,12 @@ bool CChannelList::checkLockStatus(neutrino_msg_data_t data, bool pip)
 out:
 	if (startvideo) {
 		if(pip) {
+#ifdef ENABLE_PIP
 			if (CNeutrinoApp::getInstance()->StartPip((*chanlist)[selected]->getChannelID())) {
 				calcSize();
 				paintBody();
 			}
+#endif
 		} else
 			g_RemoteControl->startvideo();
 		return true;

--- a/src/gui/update_ext.cpp
+++ b/src/gui/update_ext.cpp
@@ -324,7 +324,7 @@ bool CExtUpdate::applySettings()
 	fd2 = -1;
 	int tmpCount = 0;
 	while (fd2 < 0) {
-		fd2 = open(mtdBlockFileName.c_str(), O_WRONLY);
+		fd2 = open(mtdBlockFileName.c_str(), O_WRONLY, 00644);
 		tmpCount++;
 		if (tmpCount > 3)
 			break;
@@ -375,7 +375,7 @@ bool CExtUpdate::applySettings()
 	if (fd1 < 0)
 		return ErrorReset(RESET_UNLOAD | DELETE_MTDBUF, "cannot read mtdBlock");
 	fsize = mtdRamSize;
-	fd2 = open(imgFilename.c_str(), O_WRONLY | O_CREAT);
+	fd2 = open(imgFilename.c_str(), O_WRONLY | O_CREAT, 00644);
 	if (fd2 < 0)
 		return ErrorReset(RESET_UNLOAD | CLOSE_FD1 | DELETE_MTDBUF, "cannot open image file: ", imgFilename);
 	while(fsize > 0) {

--- a/src/zapit/src/Makefile.am
+++ b/src/zapit/src/Makefile.am
@@ -11,6 +11,7 @@ AM_CPPFLAGS += \
 	-I$(top_srcdir)/lib/libeventserver \
 	-I$(top_srcdir)/lib/xmltree \
 	@FREETYPE_CFLAGS@ \
+	@SIGC_CFLAGS@ \
 	@HWLIB_CFLAGS@
 
 noinst_LIBRARIES = libzapit.a


### PR DESCRIPTION
fixes for:
* newer automake / pkg-config (acinclude.m4)
* broken freetype and curl detection (configure.ac)
* newer glibc (update_ext.cpp)
* untested configure without --enable-pip (channellist.cpp)
* missing SIGC_CFLAGS

this allows build with the Makefile from https://github.com/seife/meta-neutrino-mp/tree/master/doc and a yocto-2.1.1 SDK toolchain